### PR TITLE
Update version bounds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
 # Changelog for math-programming-api-tests
 
-## Unreleased changes
+## [0.4.0] -- 5 July 2020
+
+Update version bounds.
+
+## [0.3.0] -- 18 June 2020
+
+Initial release.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                math-programming-tests
-version:             0.3.0
+version:             0.4.0
 github:              "prsteele/math-programming-tests"
 license:             BSD3
 author:              "Patrick Steele"

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,4 @@ packages:
   - .
 
 extra-deps:
-  - math-programming-0.3.0
+  - math-programming-0.4.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: math-programming-0.4.0@sha256:bf6476d211029e3682b9b1a131dc96957efae0d45aa59921fe0e79023306d60b,1838
+    pantry-tree:
+      size: 603
+      sha256: a891b00ad5d701cd803a7b9bffe3a72758a5da6a6de91132084271a22d1bf080
+  original:
+    hackage: math-programming-0.4.0
 snapshots:
 - completed:
-    size: 495200
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/6.yaml
-    sha256: 3baf62db5746f24561641bc15aadddbf5c973a5a1d587beb9eb9ddb4cf5628eb
-  original: lts-13.6
+    size: 524996
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/27.yaml
+    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
+  original: lts-14.27


### PR DESCRIPTION
Update version bounds to allow tests targeting `math-programming-0.4.0`. No actual API changes are made.